### PR TITLE
Move production steward to main

### DIFF
--- a/apps/production/steward/patch-deployment.yaml
+++ b/apps/production/steward/patch-deployment.yaml
@@ -7,5 +7,5 @@ spec:
     spec:
       containers:
       - name: steward
-        image: ghcr.io/profianinc/steward:0.2.0-rc2
-        imagePullPolicy: Always
+        image: ghcr.io/profianinc/steward@sha256:f60eeb8a33dda5c6a48c69cc52868f7473bf306940848b01885dd2c0f37371a3
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
There is currently no release that contains [1], so let's for now just deploy the main branch until a release is tagged.

[1]: https://github.com/profianinc/steward/commit/5868aa711df2385a9566fc2688da8d8a345fa245
Signed-off-by: Patrick Uiterwijk <patrick@profian.com>